### PR TITLE
Add/CanSetShotgunOnEnemyGun

### DIFF
--- a/src/Assets/Saeki/Scripts/BulletBaseClass.cs
+++ b/src/Assets/Saeki/Scripts/BulletBaseClass.cs
@@ -28,7 +28,7 @@ public class BulletBaseClass : MonoBehaviour
         {
             Forward = TargetManeger.getPlayerObj().transform.position - transform.position + Vector3.up * 0.5f;
         }
-
+        Forward = transform.forward;
         Forward.Normalize();
 
         Quaternion look = Quaternion.LookRotation(Forward);

--- a/src/Assets/Saeki/Scripts/EnemyBaseClass.cs
+++ b/src/Assets/Saeki/Scripts/EnemyBaseClass.cs
@@ -135,6 +135,7 @@ public class EnemyBaseClass : CharacterStatus
     void OnFire()
     {
         remainingCount = 0f;
+        gunObject.transform.LookAt(TargetManeger.getPlayerObj().transform.position + Vector3.up * 0.4f);
         if(guns.Shoot(gunObject.transform.position, gunObject.transform.forward, this.tag, true))
         {
             remainingBullets--;

--- a/src/Assets/Saeki/Scripts/TargetManeger.cs
+++ b/src/Assets/Saeki/Scripts/TargetManeger.cs
@@ -124,7 +124,7 @@ public class TargetManeger : MonoBehaviour
         List<EnemyBaseClass> list = new();
         foreach (EnemyBaseClass baseClass in Enemy)
         {
-            if (distance_Square(position ,baseClass.transform.position) < radius)
+            if (distance_Square(position ,baseClass.transform.position) < radius * radius)
                 list.Add(baseClass);
         }
         return list;

--- a/src/Assets/Sakaida/Scene/MainGameTestMapVer2.unity
+++ b/src/Assets/Sakaida/Scene/MainGameTestMapVer2.unity
@@ -11435,6 +11435,7 @@ MonoBehaviour:
   remainingBullets: 9999
   lockonIntarval: 3
   deadSound: {fileID: 0}
+  deadHead: {fileID: 0}
   enemyAliveController: {fileID: 0}
   playerController: {fileID: 0}
 --- !u!4 &329487025 stripped
@@ -20504,6 +20505,7 @@ MonoBehaviour:
   remainingBullets: 9999
   lockonIntarval: 3
   deadSound: {fileID: 0}
+  deadHead: {fileID: 0}
   enemyAliveController: {fileID: 0}
   playerController: {fileID: 0}
 --- !u!4 &586932269 stripped
@@ -45962,133 +45964,6 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 3cef207100ec1b04895cc8e12107b290, type: 3}
---- !u!1001 &1004551596
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 2472691309469408438, guid: c847afde25ac2eb408370e8644888222, type: 3}
-      propertyPath: m_Center.y
-      value: 1.43
-      objectReference: {fileID: 0}
-    - target: {fileID: 5923763736939005046, guid: c847afde25ac2eb408370e8644888222, type: 3}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7199755588353856229, guid: c847afde25ac2eb408370e8644888222, type: 3}
-      propertyPath: m_Name
-      value: EnemyWithModel_ChaseDiscovery Variant (15)
-      objectReference: {fileID: 0}
-    - target: {fileID: 7539442642854561887, guid: c847afde25ac2eb408370e8644888222, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7539442642854561887, guid: c847afde25ac2eb408370e8644888222, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7539442642854561887, guid: c847afde25ac2eb408370e8644888222, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7539442642854561887, guid: c847afde25ac2eb408370e8644888222, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7539442642854561887, guid: c847afde25ac2eb408370e8644888222, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7539442642854561887, guid: c847afde25ac2eb408370e8644888222, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7539442642854561887, guid: c847afde25ac2eb408370e8644888222, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7539442642854561887, guid: c847afde25ac2eb408370e8644888222, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7539442642854561887, guid: c847afde25ac2eb408370e8644888222, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 180
-      objectReference: {fileID: 0}
-    - target: {fileID: 7539442642854561887, guid: c847afde25ac2eb408370e8644888222, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8827271648042758507, guid: c847afde25ac2eb408370e8644888222, type: 3}
-      propertyPath: guns
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 8827271648042758507, guid: c847afde25ac2eb408370e8644888222, type: 3}
-      propertyPath: gunObject
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 8827271648042758507, guid: c847afde25ac2eb408370e8644888222, type: 3}
-      propertyPath: collScript
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 8827271648042758507, guid: c847afde25ac2eb408370e8644888222, type: 3}
-      propertyPath: playerController
-      value: 
-      objectReference: {fileID: 9100000, guid: 475a30724a729de48a5b7c2701800169, type: 2}
-    - target: {fileID: 8827271648042758507, guid: c847afde25ac2eb408370e8644888222, type: 3}
-      propertyPath: enemyAliveController
-      value: 
-      objectReference: {fileID: 9100000, guid: 4f881c0e429454c44941ee5b6bc2f519, type: 2}
-    m_RemovedComponents:
-    - {fileID: 2472691309469408438, guid: c847afde25ac2eb408370e8644888222, type: 3}
-    - {fileID: 8827271648042758507, guid: c847afde25ac2eb408370e8644888222, type: 3}
-    - {fileID: 2047314666303436268, guid: c847afde25ac2eb408370e8644888222, type: 3}
-    - {fileID: 471801400938497021, guid: c847afde25ac2eb408370e8644888222, type: 3}
-    m_RemovedGameObjects:
-    - {fileID: 6338904103209848198, guid: c847afde25ac2eb408370e8644888222, type: 3}
-    - {fileID: 409501933901870803, guid: c847afde25ac2eb408370e8644888222, type: 3}
-    - {fileID: 5923763736939005046, guid: c847afde25ac2eb408370e8644888222, type: 3}
-    - {fileID: 4510939849687488726, guid: c847afde25ac2eb408370e8644888222, type: 3}
-    - {fileID: 6326745731871836592, guid: c847afde25ac2eb408370e8644888222, type: 3}
-    - {fileID: 430141720370176182, guid: c847afde25ac2eb408370e8644888222, type: 3}
-    - {fileID: 3160709484743134671, guid: c847afde25ac2eb408370e8644888222, type: 3}
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 2306403000559302646, guid: c847afde25ac2eb408370e8644888222, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 1004551598}
-  m_SourcePrefab: {fileID: 100100000, guid: c847afde25ac2eb408370e8644888222, type: 3}
---- !u!1 &1004551597 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 2306403000559302646, guid: c847afde25ac2eb408370e8644888222, type: 3}
-  m_PrefabInstance: {fileID: 1004551596}
-  m_PrefabAsset: {fileID: 0}
---- !u!136 &1004551598
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1004551597}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Radius: 0.06583577
-  m_Height: 0.09176394
-  m_Direction: 1
-  m_Center: {x: -1.6543612e-24, y: -0.00080490106, z: -0.0020406803}
 --- !u!4 &1005474265 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 8302538188173661949, guid: ff0fc4e521e273241ab97a4ba12a825f, type: 3}
@@ -47232,6 +47107,7 @@ MonoBehaviour:
   remainingBullets: 9999
   lockonIntarval: 3
   deadSound: {fileID: 0}
+  deadHead: {fileID: 0}
   enemyAliveController: {fileID: 0}
   playerController: {fileID: 0}
 --- !u!1001 &1046467286
@@ -51265,6 +51141,7 @@ MonoBehaviour:
   remainingBullets: 9999
   lockonIntarval: 3
   deadSound: {fileID: 0}
+  deadHead: {fileID: 0}
   enemyAliveController: {fileID: 0}
   playerController: {fileID: 0}
 --- !u!114 &1143306015 stripped
@@ -57471,6 +57348,7 @@ MonoBehaviour:
   remainingBullets: 9999
   lockonIntarval: 3
   deadSound: {fileID: 0}
+  deadHead: {fileID: 0}
   enemyAliveController: {fileID: 0}
   playerController: {fileID: 0}
 --- !u!1001 &1211922583
@@ -82203,6 +82081,7 @@ MonoBehaviour:
   remainingBullets: 9999
   lockonIntarval: 3
   deadSound: {fileID: 0}
+  deadHead: {fileID: 0}
   enemyAliveController: {fileID: 0}
   playerController: {fileID: 0}
 --- !u!4 &1760241927 stripped
@@ -92534,6 +92413,7 @@ MonoBehaviour:
   remainingBullets: 9999
   lockonIntarval: 3
   deadSound: {fileID: 0}
+  deadHead: {fileID: 0}
   enemyAliveController: {fileID: 0}
   playerController: {fileID: 0}
 --- !u!4 &1975191621 stripped
@@ -102291,4 +102171,3 @@ SceneRoots:
   - {fileID: 2071458960}
   - {fileID: 285829387}
   - {fileID: 308855479}
-  - {fileID: 1004551596}

--- a/src/Assets/Suzuki/Datas/Characters/Player.asset
+++ b/src/Assets/Suzuki/Datas/Characters/Player.asset
@@ -16,5 +16,4 @@ MonoBehaviour:
   id: 0
   maxHp: 3
   maxPossessTime: 10
-  immunityTime: 1.5
-  deadSound: {fileID: 8300000, guid: 7c2de6ee61d98a74396fcd71bd7bd53d, type: 3}
+  immunityTime: 0.5

--- a/src/Assets/Suzuki/Datas/Weapons/ShotGun.asset
+++ b/src/Assets/Suzuki/Datas/Weapons/ShotGun.asset
@@ -17,19 +17,20 @@ MonoBehaviour:
   bulletPrefab: {fileID: 2720097741136659255, guid: 20defe61a7a48ba46a8e020f56a05f9c, type: 3}
   maxBullet: 2
   bulletSettings:
-  - diffusion: {x: 0.6, y: 0}
+  - diffusion: {x: 2.4, y: 0}
     randomNess: 0
-  - diffusion: {x: -0.6, y: 0}
+  - diffusion: {x: -2.4, y: 0}
     randomNess: 0
-  - diffusion: {x: -0.4, y: 0.6}
+  - diffusion: {x: -1.6, y: 2.4}
     randomNess: 0
-  - diffusion: {x: 0.4, y: 0.6}
+  - diffusion: {x: 1.6, y: 2.4}
     randomNess: 0
-  - diffusion: {x: -0.4, y: -0.6}
+  - diffusion: {x: -1.6, y: -2.4}
     randomNess: 0
-  - diffusion: {x: 0.4, y: -0.6}
+  - diffusion: {x: 1.6, y: -2.4}
     randomNess: 0
   weaponRole: 0
   weaponType: 2
+  shotSound: {fileID: 0}
   weaponImage: {fileID: 21300000, guid: bc3ab62b61c6c3d4a9046ba246881487, type: 3}
   subWeapon: {fileID: 3993766834917909290, guid: 03f82252fc4ff8340936cdb188a204da, type: 3}

--- a/src/Assets/Suzuki/Datas/Weapons/Sniper.asset
+++ b/src/Assets/Suzuki/Datas/Weapons/Sniper.asset
@@ -14,12 +14,13 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   name: "\u30B9\u30CA\u30A4\u30D1\u30FC"
   id: 4
-  bulletPrefab: {fileID: 2720097741136659255, guid: 20defe61a7a48ba46a8e020f56a05f9c, type: 3}
+  bulletPrefab: {fileID: 3085846872221255901, guid: a9908cc7c27a0ae468d02d602a2e1627, type: 3}
   maxBullet: 5
   bulletSettings:
   - diffusion: {x: 0, y: 0}
     randomNess: 0
   weaponRole: 0
   weaponType: 3
+  shotSound: {fileID: 8300000, guid: 5dbc74a65da58144aa0a20190bcd4909, type: 3}
   weaponImage: {fileID: 21300000, guid: bc3ab62b61c6c3d4a9046ba246881487, type: 3}
   subWeapon: {fileID: 3993766834917909290, guid: 03f82252fc4ff8340936cdb188a204da, type: 3}

--- a/src/Assets/Suzuki/Prefabs/ExplosiveBullet Variant.prefab
+++ b/src/Assets/Suzuki/Prefabs/ExplosiveBullet Variant.prefab
@@ -1,0 +1,98 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &1111433746830363626
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2720097741136659255, guid: 20defe61a7a48ba46a8e020f56a05f9c, type: 3}
+      propertyPath: m_Name
+      value: ExplosiveBullet Variant
+      objectReference: {fileID: 0}
+    - target: {fileID: 3278088209553115426, guid: 20defe61a7a48ba46a8e020f56a05f9c, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3278088209553115426, guid: 20defe61a7a48ba46a8e020f56a05f9c, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3278088209553115426, guid: 20defe61a7a48ba46a8e020f56a05f9c, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3278088209553115426, guid: 20defe61a7a48ba46a8e020f56a05f9c, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3278088209553115426, guid: 20defe61a7a48ba46a8e020f56a05f9c, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3278088209553115426, guid: 20defe61a7a48ba46a8e020f56a05f9c, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3278088209553115426, guid: 20defe61a7a48ba46a8e020f56a05f9c, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3278088209553115426, guid: 20defe61a7a48ba46a8e020f56a05f9c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3278088209553115426, guid: 20defe61a7a48ba46a8e020f56a05f9c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3278088209553115426, guid: 20defe61a7a48ba46a8e020f56a05f9c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents:
+    - {fileID: 2896952001539416241, guid: 20defe61a7a48ba46a8e020f56a05f9c, type: 3}
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 2720097741136659255, guid: 20defe61a7a48ba46a8e020f56a05f9c, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 7286970610789034506}
+  m_SourcePrefab: {fileID: 100100000, guid: 20defe61a7a48ba46a8e020f56a05f9c, type: 3}
+--- !u!1 &3085846872221255901 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2720097741136659255, guid: 20defe61a7a48ba46a8e020f56a05f9c, type: 3}
+  m_PrefabInstance: {fileID: 1111433746830363626}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &7286970610789034506
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3085846872221255901}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 256ed5e637bbace468c51a75d9ac44fa, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  DestroyIntarval: 5
+  BulletPower: 80
+  rb: {fileID: 5896891930781576254}
+  bulletData: {fileID: 11400000, guid: eee7d5ba61c5f9849a157a03244435c1, type: 2}
+  particle: {fileID: 1000996106448251057, guid: a0d91cd8f9652374cb239e0fdabe2725, type: 3}
+  hitLayerMask:
+    serializedVersion: 2
+    m_Bits: 712
+  lapseLayerMask:
+    serializedVersion: 2
+    m_Bits: 64
+  explosionRadius: 3
+  effect: {fileID: 6711175723242689865, guid: fe2e174444aa8dd49b1cc6f83382f1f7, type: 3}
+--- !u!54 &5896891930781576254 stripped
+Rigidbody:
+  m_CorrespondingSourceObject: {fileID: -2397765559653570604, guid: 20defe61a7a48ba46a8e020f56a05f9c, type: 3}
+  m_PrefabInstance: {fileID: 1111433746830363626}
+  m_PrefabAsset: {fileID: 0}

--- a/src/Assets/Suzuki/Prefabs/ExplosiveBullet Variant.prefab.meta
+++ b/src/Assets/Suzuki/Prefabs/ExplosiveBullet Variant.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a9908cc7c27a0ae468d02d602a2e1627
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Assets/Suzuki/Prefabs/Particles/BulletExplosion Variant.prefab
+++ b/src/Assets/Suzuki/Prefabs/Particles/BulletExplosion Variant.prefab
@@ -1,0 +1,87 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &5268949803138817474
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1180678301494081649, guid: 4839472538563474a9bc111b3970d203, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1180678301494081649, guid: 4839472538563474a9bc111b3970d203, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1180678301494081649, guid: 4839472538563474a9bc111b3970d203, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1180678301494081649, guid: 4839472538563474a9bc111b3970d203, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1180678301494081649, guid: 4839472538563474a9bc111b3970d203, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1180678301494081649, guid: 4839472538563474a9bc111b3970d203, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1180678301494081649, guid: 4839472538563474a9bc111b3970d203, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1180678301494081649, guid: 4839472538563474a9bc111b3970d203, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1180678301494081649, guid: 4839472538563474a9bc111b3970d203, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1180678301494081649, guid: 4839472538563474a9bc111b3970d203, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1217372941345896980, guid: 4839472538563474a9bc111b3970d203, type: 3}
+      propertyPath: ShapeModule.radius.value
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1217372941345896980, guid: 4839472538563474a9bc111b3970d203, type: 3}
+      propertyPath: InitialModule.startSize.scalar
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1217372941345896980, guid: 4839472538563474a9bc111b3970d203, type: 3}
+      propertyPath: InitialModule.startLifetime.scalar
+      value: 1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1217372941345896980, guid: 4839472538563474a9bc111b3970d203, type: 3}
+      propertyPath: VelocityModule.speedModifier.scalar
+      value: 0.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1458589230454212747, guid: 4839472538563474a9bc111b3970d203, type: 3}
+      propertyPath: m_Name
+      value: BulletExplosion Variant
+      objectReference: {fileID: 0}
+    - target: {fileID: 4397536587677987190, guid: 4839472538563474a9bc111b3970d203, type: 3}
+      propertyPath: ShapeModule.radius.value
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4397536587677987190, guid: 4839472538563474a9bc111b3970d203, type: 3}
+      propertyPath: InitialModule.startSize.scalar
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4397536587677987190, guid: 4839472538563474a9bc111b3970d203, type: 3}
+      propertyPath: InitialModule.startLifetime.scalar
+      value: 1.5
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 4839472538563474a9bc111b3970d203, type: 3}

--- a/src/Assets/Suzuki/Prefabs/Particles/BulletExplosion Variant.prefab.meta
+++ b/src/Assets/Suzuki/Prefabs/Particles/BulletExplosion Variant.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: fe2e174444aa8dd49b1cc6f83382f1f7
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Assets/Suzuki/Scripts/ExplosiveBulletScript.cs
+++ b/src/Assets/Suzuki/Scripts/ExplosiveBulletScript.cs
@@ -1,0 +1,30 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class ExplosiveBulletScript : BulletBaseClass
+{
+    [Header("爆発半径"), SerializeField] float explosionRadius;
+    [Header("爆発のエフェクト"), SerializeField] GameObject effect;
+    void OnDestroy()
+    {
+        // 弾丸が破壊される（ステージか敵に衝突した）ときに爆発
+        DamageExplosion();
+        GameObject effectObject = Instantiate(effect, transform.position, Quaternion.identity);
+    }
+
+    void DamageExplosion()
+    {
+        // プレイヤーが爆風に巻き込まれたとき
+        if ((transform.position - TargetManeger.getPlayerObj().transform.position).sqrMagnitude <= explosionRadius * explosionRadius)
+        {
+            TargetManeger.getPlayerObj().GetComponent<CharacterStatus>().TakeDamage(1f);
+        }
+        // 敵が爆風に巻き込まれたとき
+        List<EnemyBaseClass> hitEnemies = TargetManeger.TakeTarget(transform.position, explosionRadius);
+        foreach(EnemyBaseClass enemy in hitEnemies)
+        {
+            enemy.TakeDamage(9999f, true);
+        }
+    }
+}

--- a/src/Assets/Suzuki/Scripts/ExplosiveBulletScript.cs.meta
+++ b/src/Assets/Suzuki/Scripts/ExplosiveBulletScript.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 256ed5e637bbace468c51a75d9ac44fa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
・ショットガンを敵が発射できるように（持たせたい敵のGun -> GunStatus -> WeaponDataを変更することで変更できる）
・敵の発射した弾丸の進行方向の決め方を変更（弾を撃ってからプレイヤーの方向に向かせる -> 銃をプレイヤーに向けてから発射するように、ショットガンの拡散を反映させるため）
・着弾地点で爆発する弾を作成、スナイパーのデータに登録